### PR TITLE
Pass access token in the Authorization: header

### DIFF
--- a/server.js
+++ b/server.js
@@ -24,8 +24,9 @@ app.get('/auth/github', (req, res) => {
     }
   }).then(resp => {
     const {access_token} = resp.data;
-    axios.get(`https://api.github.com/user?access_token=${access_token}`, {
+    axios.get(`https://api.github.com/user`, {
       headers: {
+        'Authorization': `token ${access_token}`,
         'Accept': 'application/json'
       }
     }).then(resp => {


### PR DESCRIPTION
Passing the token in query param is now deprecated.

See https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/